### PR TITLE
feat: add Streamlit control flow exception handling and nested bounda…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "st-error-boundary"
-version = "0.1.5"
+version = "0.1.6"
 description = "A tiny, typed error-boundary decorator for Streamlit apps (UI-safe fallback + pluggable hooks)"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -107,6 +107,6 @@ dev = [
     "mypy>=1.18.2",
     "pyright>=1.1.406",
     "pytest>=8.4.2",
-    "ruff>=0.13.3",
+    "ruff>=0.14.0",
     "pytest-cov>=7.0.0,<8",
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,3 @@
-"""Integration tests for ErrorBoundary using Streamlit AppTest."""
-
 from __future__ import annotations
 
 from streamlit.testing.v1 import AppTest
@@ -413,3 +411,591 @@ main()
     assert at.session_state.error_message == "Selection error"  # type: ignore[unreachable]
     assert len(at.error) == 1
     assert at.error[0].value == "Error handling selection"
+
+
+def test_rerun_passes_through_in_decorate() -> None:
+    """Test that st.rerun() passes through ErrorBoundary in decorated functions."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+boundary = ErrorBoundary(on_error=lambda _: None, fallback="Error occurred")
+
+@boundary.decorate
+def main() -> None:
+    st.write("before rerun")
+    if st.button("Trigger Rerun"):
+        st.rerun()
+    st.write("after rerun")
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially both texts should appear
+    markdown_values = [m.value for m in at.markdown]
+    assert any("before rerun" in v for v in markdown_values)
+    assert any("after rerun" in v for v in markdown_values)
+
+    # Click button to trigger rerun
+    at.button[0].click()
+    at.run()
+
+    # After rerun, script should restart from beginning
+    markdown_values = [m.value for m in at.markdown]
+    assert any("before rerun" in v for v in markdown_values)
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_stop_passes_through_in_decorate() -> None:
+    """Test that st.stop() passes through ErrorBoundary in decorated functions."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+boundary = ErrorBoundary(on_error=lambda _: None, fallback="Error occurred")
+
+@boundary.decorate
+def main() -> None:
+    st.write("before stop")
+    if st.button("Trigger Stop"):
+        st.write("stopping now")
+        st.stop()
+        st.write("this should never appear")
+    st.write("after stop")
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially "before stop" and "after stop" appear
+    markdown_values = [m.value for m in at.markdown]
+    assert any("before stop" in v for v in markdown_values)
+    assert any("after stop" in v for v in markdown_values)
+
+    # Click button to trigger stop
+    at.button[0].click()
+    at.run()
+
+    # "stopping now" should appear, but "this should never appear" should not
+    markdown_values = [m.value for m in at.markdown]
+    assert any("before stop" in v for v in markdown_values)
+    assert any("stopping now" in v for v in markdown_values)
+    # Content after st.stop() should not appear
+    assert not any("this should never appear" in v for v in markdown_values)
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_rerun_passes_through_in_callback() -> None:
+    """Test that st.rerun() passes through ErrorBoundary in wrapped callbacks."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "counter" not in st.session_state:
+    st.session_state.counter = 0
+
+boundary = ErrorBoundary(on_error=lambda _: None, fallback="Error occurred")
+
+def trigger_rerun() -> None:
+    st.session_state.counter += 1
+    st.rerun()
+
+@boundary.decorate
+def main() -> None:
+    st.write(f"Counter: {st.session_state.counter}")
+    st.button("Increment and Rerun", on_click=boundary.wrap_callback(trigger_rerun))
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially counter is 0
+    markdown_values = [m.value for m in at.markdown]
+    assert any("Counter: 0" in v for v in markdown_values)
+
+    # Click button to trigger rerun
+    at.button[0].click()
+    at.run()
+
+    # Counter should be incremented and rerun should have occurred
+    markdown_values = [m.value for m in at.markdown]
+    assert any("Counter: 1" in v for v in markdown_values)
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_stop_passes_through_in_callback() -> None:
+    """Test that st.stop() passes through ErrorBoundary in wrapped callbacks.
+
+    Note: When st.stop() is called in a callback, it stops the entire script execution
+    immediately after the callback completes. This test verifies that st.stop() is not
+    caught by the error boundary and allows Streamlit to handle it correctly.
+    """
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "error_triggered" not in st.session_state:
+    st.session_state.error_triggered = False
+
+boundary = ErrorBoundary(
+    on_error=lambda _: st.session_state.update(error_triggered=True),
+    fallback="Error occurred"
+)
+
+def trigger_stop() -> None:
+    # This should pass through without triggering error handler
+    st.stop()
+
+@boundary.decorate
+def main() -> None:
+    st.write("start")
+    st.button("Trigger Stop", on_click=boundary.wrap_callback(trigger_stop))
+    st.write("end")
+
+main()
+
+# Verify error was not triggered
+st.write(f"Error triggered: {st.session_state.error_triggered}")
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially everything renders
+    markdown_values = [m.value for m in at.markdown]
+    assert any("start" in v for v in markdown_values)
+    assert any("end" in v for v in markdown_values)
+    assert any("Error triggered: False" in v for v in markdown_values)
+
+    # Click button to trigger stop in callback
+    at.button[0].click()
+    at.run()
+
+    # After st.stop() in callback, script execution stops
+    # The key point is that error_triggered should still be False
+    # (meaning st.stop() was not caught as an error)
+    assert at.session_state.error_triggered is False
+    # No error fallback should be shown
+    assert len(at.error) == 0
+
+
+# ============================================================================
+# Nested boundary tests
+# ============================================================================
+
+
+def test_nested_inner_handles_only() -> None:
+    """Test that inner boundary handles exception, not outer boundary.
+
+    When ErrorBoundaries are nested, the innermost boundary that catches
+    the exception should handle it. The outer boundary's hooks should NOT
+    be executed.
+    """
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+# Initialize observation flags
+if "inner_hook" not in st.session_state:
+    st.session_state.inner_hook = False
+if "outer_hook" not in st.session_state:
+    st.session_state.outer_hook = False
+
+def inner_hook(_: Exception) -> None:
+    st.session_state.inner_hook = True
+
+def outer_hook(_: Exception) -> None:
+    st.session_state.outer_hook = True
+
+# Create nested boundaries
+outer = ErrorBoundary(on_error=outer_hook, fallback="OUTER FALLBACK")
+inner = ErrorBoundary(on_error=inner_hook, fallback="INNER FALLBACK")
+
+@outer.decorate
+def main() -> None:
+    st.write("start")
+
+    @inner.decorate
+    def section() -> None:
+        if st.button("Boom"):
+            raise ValueError("boom")
+
+    section()
+    st.write("end")
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially no error
+    assert at.session_state.inner_hook is False
+    assert at.session_state.outer_hook is False
+
+    # Trigger exception
+    at.button[0].click()
+    at.run()
+
+    # Inner fallback should be shown, not outer
+    assert len(at.error) == 1
+    assert at.error[0].value == "INNER FALLBACK"
+
+    # Inner hook should be executed, outer hook should NOT
+    assert at.session_state.inner_hook is True
+    assert at.session_state.outer_hook is False  # type: ignore[unreachable]
+
+
+def test_nested_inner_fallback_raises_bubbles_to_outer() -> None:
+    """Test that exception from inner fallback bubbles to outer boundary.
+
+    If the inner fallback raises an exception, it should propagate to the
+    outer boundary, which will handle it. Both inner and outer hooks should
+    be executed (inner first, then outer).
+    """
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+# Initialize observation flags
+if "inner_hook" not in st.session_state:
+    st.session_state.inner_hook = False
+if "outer_hook" not in st.session_state:
+    st.session_state.outer_hook = False
+
+def inner_hook(_: Exception) -> None:
+    st.session_state.inner_hook = True
+
+def outer_hook(_: Exception) -> None:
+    st.session_state.outer_hook = True
+
+def bad_inner_fallback(_: Exception) -> None:
+    # Intentionally raise to propagate to outer boundary
+    msg = "fallback failed"
+    raise RuntimeError(msg)
+
+# Create nested boundaries
+outer = ErrorBoundary(on_error=outer_hook, fallback="OUTER FALLBACK")
+inner = ErrorBoundary(on_error=inner_hook, fallback=bad_inner_fallback)
+
+@outer.decorate
+def main() -> None:
+    @inner.decorate
+    def section() -> None:
+        if st.button("Boom"):
+            msg = "boom"
+            raise ValueError(msg)
+
+    section()
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially no error
+    assert at.session_state.inner_hook is False
+    assert at.session_state.outer_hook is False
+
+    # Trigger exception (inner fallback will raise)
+    at.button[0].click()
+    at.run()
+
+    # Outer fallback should be shown (inner fallback raised exception)
+    assert len(at.error) == 1
+    assert at.error[0].value == "OUTER FALLBACK"
+
+    # Both hooks should have been executed (inner first, then outer)
+    assert at.session_state.inner_hook is True
+    assert at.session_state.outer_hook is True  # type: ignore[unreachable]
+
+
+def test_nested_fallback_raise_hooks_run_inner_then_outer() -> None:
+    """Test that when inner fallback raises, hooks execute in order: inner then outer.
+
+    This verifies the execution order guarantee for nested boundaries when
+    the inner fallback propagates an exception to the outer boundary.
+    """
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "order" not in st.session_state:
+    st.session_state.order = []
+
+def inner_hook(_: Exception) -> None:
+    st.session_state.order.append("inner")
+
+def outer_hook(_: Exception) -> None:
+    st.session_state.order.append("outer")
+
+def bad_inner_fallback(_: Exception) -> None:
+    msg = "fallback failed"
+    raise RuntimeError(msg)
+
+outer = ErrorBoundary(on_error=outer_hook, fallback="OUTER")
+inner = ErrorBoundary(on_error=inner_hook, fallback=bad_inner_fallback)
+
+@outer.decorate
+def main() -> None:
+    @inner.decorate
+    def section() -> None:
+        if st.button("Boom"):
+            msg = "boom"
+            raise ValueError(msg)
+    section()
+
+main()
+"""
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially no hooks called
+    assert at.session_state.order == []
+
+    # Trigger exception
+    at.button[0].click()
+    at.run()
+
+    # Outer fallback shown (inner fallback raised)
+    assert len(at.error) == 1
+    assert at.error[0].value == "OUTER"
+
+    # Hooks executed in order: inner first, then outer
+    assert at.session_state.order == ["inner", "outer"]
+
+
+def test_nested_with_callback_inner_handles_only() -> None:
+    """Test that nested boundaries with wrap_callback follow the same rules.
+
+    Verifies that when a callback raises an exception within nested boundaries,
+    only the innermost boundary's hooks are called (same as decorate behavior).
+    """
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "inner" not in st.session_state:
+    st.session_state.inner = False
+if "outer" not in st.session_state:
+    st.session_state.outer = False
+
+def inner_hook(_: Exception) -> None:
+    st.session_state.inner = True
+
+def outer_hook(_: Exception) -> None:
+    st.session_state.outer = True
+
+outer = ErrorBoundary(on_error=outer_hook, fallback="OUTER")
+inner = ErrorBoundary(on_error=inner_hook, fallback="INNER")
+
+def cb() -> None:
+    msg = "cb error"
+    raise RuntimeError(msg)
+
+@outer.decorate
+def main() -> None:
+    @inner.decorate
+    def section() -> None:
+        st.button("Boom", on_click=inner.wrap_callback(cb))
+    section()
+
+main()
+"""
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially no hooks called
+    assert at.session_state.inner is False
+    assert at.session_state.outer is False
+
+    # Trigger callback exception
+    at.button[0].click()
+    at.run()
+
+    # Inner fallback shown (callback error caught by inner boundary)
+    assert len(at.error) == 1
+    assert at.error[0].value == "INNER"
+
+    # Only inner hook called, outer hook NOT called
+    assert at.session_state.inner is True
+    assert at.session_state.outer is False  # type: ignore[unreachable]
+
+
+def test_rerun_does_not_call_hook_in_decorate() -> None:
+    """Test that st.rerun() does not trigger error hooks in decorated functions."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "hook_called" not in st.session_state:
+    st.session_state.hook_called = False
+
+def hook(_: Exception) -> None:
+    st.session_state.hook_called = True
+
+boundary = ErrorBoundary(on_error=hook, fallback="fallback")
+
+@boundary.decorate
+def main() -> None:
+    st.write("before rerun")
+    if st.button("Rerun"):
+        st.rerun()
+    st.write("after rerun")
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially hook not called
+    assert at.session_state.hook_called is False
+
+    # Click button to trigger rerun
+    at.button[0].click()
+    at.run()
+
+    # Hook should NOT be called because st.rerun() is a control flow exception
+    assert at.session_state.hook_called is False
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_stop_does_not_call_hook_in_decorate() -> None:
+    """Test that st.stop() does not trigger error hooks in decorated functions."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "hook_called" not in st.session_state:
+    st.session_state.hook_called = False
+
+def hook(_: Exception) -> None:
+    st.session_state.hook_called = True
+
+boundary = ErrorBoundary(on_error=hook, fallback="fallback")
+
+@boundary.decorate
+def main() -> None:
+    st.write("before stop")
+    if st.button("Stop"):
+        st.write("stopping now")
+        st.stop()
+    st.write("after stop")
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially hook not called
+    assert at.session_state.hook_called is False
+
+    # Click button to trigger stop
+    at.button[0].click()
+    at.run()
+
+    # Hook should NOT be called because st.stop() is a control flow exception
+    assert at.session_state.hook_called is False
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_rerun_does_not_call_hook_in_callback() -> None:
+    """Test that st.rerun() does not trigger error hooks in wrapped callbacks."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "hook_called" not in st.session_state:
+    st.session_state.hook_called = False
+if "counter" not in st.session_state:
+    st.session_state.counter = 0
+
+def hook(_: Exception) -> None:
+    st.session_state.hook_called = True
+
+boundary = ErrorBoundary(on_error=hook, fallback="fallback")
+
+def trigger_rerun() -> None:
+    st.session_state.counter += 1
+    st.rerun()
+
+@boundary.decorate
+def main() -> None:
+    st.write(f"Counter: {st.session_state.counter}")
+    st.button("Rerun", on_click=boundary.wrap_callback(trigger_rerun))
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially hook not called
+    assert at.session_state.hook_called is False
+    assert at.session_state.counter == 0
+
+    # Click button to trigger rerun
+    at.button[0].click()
+    at.run()
+
+    # Counter should be incremented and rerun should have occurred
+    assert at.session_state.counter == 1
+    # Hook should NOT be called because st.rerun() is a control flow exception
+    assert at.session_state.hook_called is False
+    # No error should be shown
+    assert len(at.error) == 0
+
+
+def test_stop_does_not_call_hook_in_callback() -> None:
+    """Test that st.stop() does not trigger error hooks in wrapped callbacks."""
+    script = """
+import streamlit as st
+from st_error_boundary import ErrorBoundary
+
+if "hook_called" not in st.session_state:
+    st.session_state.hook_called = False
+
+def hook(_: Exception) -> None:
+    st.session_state.hook_called = True
+
+boundary = ErrorBoundary(on_error=hook, fallback="fallback")
+
+def trigger_stop() -> None:
+    st.stop()
+
+@boundary.decorate
+def main() -> None:
+    st.button("Stop", on_click=boundary.wrap_callback(trigger_stop))
+
+main()
+"""
+
+    at = AppTest.from_string(script)
+    at.run()
+
+    # Initially hook not called
+    assert at.session_state.hook_called is False
+
+    # Click button to trigger stop
+    at.button[0].click()
+    at.run()
+
+    # Hook should NOT be called because st.stop() is a control flow exception
+    assert at.session_state.hook_called is False
+    # No error should be shown
+    assert len(at.error) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -838,28 +838,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.13.3"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/8e/f9f9ca747fea8e3ac954e3690d4698c9737c23b51731d02df999c150b1c9/ruff-0.13.3.tar.gz", hash = "sha256:5b0ba0db740eefdfbcce4299f49e9eaefc643d4d007749d77d047c2bab19908e", size = 5438533, upload-time = "2025-10-02T19:29:31.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/b9/9bd84453ed6dd04688de9b3f3a4146a1698e8faae2ceeccce4e14c67ae17/ruff-0.14.0.tar.gz", hash = "sha256:62ec8969b7510f77945df916de15da55311fade8d6050995ff7f680afe582c57", size = 5452071, upload-time = "2025-10-07T18:21:55.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/33/8f7163553481466a92656d35dea9331095122bb84cf98210bef597dd2ecd/ruff-0.13.3-py3-none-linux_armv6l.whl", hash = "sha256:311860a4c5e19189c89d035638f500c1e191d283d0cc2f1600c8c80d6dcd430c", size = 12484040, upload-time = "2025-10-02T19:28:49.199Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b5/4a21a4922e5dd6845e91896b0d9ef493574cbe061ef7d00a73c61db531af/ruff-0.13.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2bdad6512fb666b40fcadb65e33add2b040fc18a24997d2e47fee7d66f7fcae2", size = 13122975, upload-time = "2025-10-02T19:28:52.446Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/15649af836d88c9f154e5be87e64ae7d2b1baa5a3ef317cb0c8fafcd882d/ruff-0.13.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fc6fa4637284708d6ed4e5e970d52fc3b76a557d7b4e85a53013d9d201d93286", size = 12346621, upload-time = "2025-10-02T19:28:54.712Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/bcbccb8141305f9a6d3f72549dd82d1134299177cc7eaf832599700f95a7/ruff-0.13.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c9e6469864f94a98f412f20ea143d547e4c652f45e44f369d7b74ee78185838", size = 12574408, upload-time = "2025-10-02T19:28:56.679Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/19/0f3681c941cdcfa2d110ce4515624c07a964dc315d3100d889fcad3bfc9e/ruff-0.13.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5bf62b705f319476c78891e0e97e965b21db468b3c999086de8ffb0d40fd2822", size = 12285330, upload-time = "2025-10-02T19:28:58.79Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f8/387976bf00d126b907bbd7725219257feea58650e6b055b29b224d8cb731/ruff-0.13.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78cc1abed87ce40cb07ee0667ce99dbc766c9f519eabfd948ed87295d8737c60", size = 13980815, upload-time = "2025-10-02T19:29:01.577Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a6/7c8ec09d62d5a406e2b17d159e4817b63c945a8b9188a771193b7e1cc0b5/ruff-0.13.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4fb75e7c402d504f7a9a259e0442b96403fa4a7310ffe3588d11d7e170d2b1e3", size = 14987733, upload-time = "2025-10-02T19:29:04.036Z" },
-    { url = "https://files.pythonhosted.org/packages/97/e5/f403a60a12258e0fd0c2195341cfa170726f254c788673495d86ab5a9a9d/ruff-0.13.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:17b951f9d9afb39330b2bdd2dd144ce1c1335881c277837ac1b50bfd99985ed3", size = 14439848, upload-time = "2025-10-02T19:29:06.684Z" },
-    { url = "https://files.pythonhosted.org/packages/39/49/3de381343e89364c2334c9f3268b0349dc734fc18b2d99a302d0935c8345/ruff-0.13.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6052f8088728898e0a449f0dde8fafc7ed47e4d878168b211977e3e7e854f662", size = 13421890, upload-time = "2025-10-02T19:29:08.767Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b5/c0feca27d45ae74185a6bacc399f5d8920ab82df2d732a17213fb86a2c4c/ruff-0.13.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc742c50f4ba72ce2a3be362bd359aef7d0d302bf7637a6f942eaa763bd292af", size = 13444870, upload-time = "2025-10-02T19:29:11.234Z" },
-    { url = "https://files.pythonhosted.org/packages/50/a1/b655298a1f3fda4fdc7340c3f671a4b260b009068fbeb3e4e151e9e3e1bf/ruff-0.13.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8e5640349493b378431637019366bbd73c927e515c9c1babfea3e932f5e68e1d", size = 13691599, upload-time = "2025-10-02T19:29:13.353Z" },
-    { url = "https://files.pythonhosted.org/packages/32/b0/a8705065b2dafae007bcae21354e6e2e832e03eb077bb6c8e523c2becb92/ruff-0.13.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6b139f638a80eae7073c691a5dd8d581e0ba319540be97c343d60fb12949c8d0", size = 12421893, upload-time = "2025-10-02T19:29:15.668Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/1e/cbe7082588d025cddbb2f23e6dfef08b1a2ef6d6f8328584ad3015b5cebd/ruff-0.13.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6b547def0a40054825de7cfa341039ebdfa51f3d4bfa6a0772940ed351d2746c", size = 12267220, upload-time = "2025-10-02T19:29:17.583Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/99/4086f9c43f85e0755996d09bdcb334b6fee9b1eabdf34e7d8b877fadf964/ruff-0.13.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9cc48a3564423915c93573f1981d57d101e617839bef38504f85f3677b3a0a3e", size = 13177818, upload-time = "2025-10-02T19:29:19.943Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/de/7b5db7e39947d9dc1c5f9f17b838ad6e680527d45288eeb568e860467010/ruff-0.13.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1a993b17ec03719c502881cb2d5f91771e8742f2ca6de740034433a97c561989", size = 13618715, upload-time = "2025-10-02T19:29:22.527Z" },
-    { url = "https://files.pythonhosted.org/packages/28/d3/bb25ee567ce2f61ac52430cf99f446b0e6d49bdfa4188699ad005fdd16aa/ruff-0.13.3-py3-none-win32.whl", hash = "sha256:f14e0d1fe6460f07814d03c6e32e815bff411505178a1f539a38f6097d3e8ee3", size = 12334488, upload-time = "2025-10-02T19:29:24.782Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/49/12f5955818a1139eed288753479ba9d996f6ea0b101784bb1fe6977ec128/ruff-0.13.3-py3-none-win_amd64.whl", hash = "sha256:621e2e5812b691d4f244638d693e640f188bacbb9bc793ddd46837cea0503dd2", size = 13455262, upload-time = "2025-10-02T19:29:26.882Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/72/7b83242b26627a00e3af70d0394d68f8f02750d642567af12983031777fc/ruff-0.13.3-py3-none-win_arm64.whl", hash = "sha256:9e9e9d699841eaf4c2c798fa783df2fabc680b72059a02ca0ed81c460bc58330", size = 12538484, upload-time = "2025-10-02T19:29:28.951Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/4e/79d463a5f80654e93fa653ebfb98e0becc3f0e7cf6219c9ddedf1e197072/ruff-0.14.0-py3-none-linux_armv6l.whl", hash = "sha256:58e15bffa7054299becf4bab8a1187062c6f8cafbe9f6e39e0d5aface455d6b3", size = 12494532, upload-time = "2025-10-07T18:21:00.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/40/e2392f445ed8e02aa6105d49db4bfff01957379064c30f4811c3bf38aece/ruff-0.14.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:838d1b065f4df676b7c9957992f2304e41ead7a50a568185efd404297d5701e8", size = 13160768, upload-time = "2025-10-07T18:21:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/75/da/2a656ea7c6b9bd14c7209918268dd40e1e6cea65f4bb9880eaaa43b055cd/ruff-0.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:703799d059ba50f745605b04638fa7e9682cc3da084b2092feee63500ff3d9b8", size = 12363376, upload-time = "2025-10-07T18:21:07.833Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/1ffef5a1875add82416ff388fcb7ea8b22a53be67a638487937aea81af27/ruff-0.14.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ba9a8925e90f861502f7d974cc60e18ca29c72bb0ee8bfeabb6ade35a3abde7", size = 12608055, upload-time = "2025-10-07T18:21:10.72Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/32/986725199d7cee510d9f1dfdf95bf1efc5fa9dd714d0d85c1fb1f6be3bc3/ruff-0.14.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e41f785498bd200ffc276eb9e1570c019c1d907b07cfb081092c8ad51975bbe7", size = 12318544, upload-time = "2025-10-07T18:21:13.741Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ed/4969cefd53315164c94eaf4da7cfba1f267dc275b0abdd593d11c90829a3/ruff-0.14.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30a58c087aef4584c193aebf2700f0fbcfc1e77b89c7385e3139956fa90434e2", size = 14001280, upload-time = "2025-10-07T18:21:16.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ad/96c1fc9f8854c37681c9613d825925c7f24ca1acfc62a4eb3896b50bacd2/ruff-0.14.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f8d07350bc7af0a5ce8812b7d5c1a7293cf02476752f23fdfc500d24b79b783c", size = 15027286, upload-time = "2025-10-07T18:21:19.577Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/1426978f97df4fe331074baf69615f579dc4e7c37bb4c6f57c2aad80c87f/ruff-0.14.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eec3bbbf3a7d5482b5c1f42d5fc972774d71d107d447919fca620b0be3e3b75e", size = 14451506, upload-time = "2025-10-07T18:21:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/9c1cea6e493c0cf0647674cca26b579ea9d2a213b74b5c195fbeb9678e15/ruff-0.14.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:16b68e183a0e28e5c176d51004aaa40559e8f90065a10a559176713fcf435206", size = 13437384, upload-time = "2025-10-07T18:21:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b4/4cd6a4331e999fc05d9d77729c95503f99eae3ba1160469f2b64866964e3/ruff-0.14.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb732d17db2e945cfcbbc52af0143eda1da36ca8ae25083dd4f66f1542fdf82e", size = 13447976, upload-time = "2025-10-07T18:21:28.83Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c0/ac42f546d07e4f49f62332576cb845d45c67cf5610d1851254e341d563b6/ruff-0.14.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c958f66ab884b7873e72df38dcabee03d556a8f2ee1b8538ee1c2bbd619883dd", size = 13682850, upload-time = "2025-10-07T18:21:31.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/4b0c9bcadd45b4c29fe1af9c5d1dc0ca87b4021665dfbe1c4688d407aa20/ruff-0.14.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7eb0499a2e01f6e0c285afc5bac43ab380cbfc17cd43a2e1dd10ec97d6f2c42d", size = 12449825, upload-time = "2025-10-07T18:21:35.074Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a8/e2e76288e6c16540fa820d148d83e55f15e994d852485f221b9524514730/ruff-0.14.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4c63b2d99fafa05efca0ab198fd48fa6030d57e4423df3f18e03aa62518c565f", size = 12272599, upload-time = "2025-10-07T18:21:38.08Z" },
+    { url = "https://files.pythonhosted.org/packages/18/14/e2815d8eff847391af632b22422b8207704222ff575dec8d044f9ab779b2/ruff-0.14.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:668fce701b7a222f3f5327f86909db2bbe99c30877c8001ff934c5413812ac02", size = 13193828, upload-time = "2025-10-07T18:21:41.216Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c6/61ccc2987cf0aecc588ff8f3212dea64840770e60d78f5606cd7dc34de32/ruff-0.14.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a86bf575e05cb68dcb34e4c7dfe1064d44d3f0c04bbc0491949092192b515296", size = 13628617, upload-time = "2025-10-07T18:21:44.04Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "st-error-boundary"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "streamlit" },
@@ -906,7 +906,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.406" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8" },
-    { name = "ruff", specifier = ">=0.13.3" },
+    { name = "ruff", specifier = ">=0.14.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "st-error-boundary"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "streamlit" },


### PR DESCRIPTION
### add Streamlit control flow exception handling and nested boundary behavior.

- Add _is_streamlit_control_flow() and _should_passthrough() helpers
- Update decorate() and wrap_callback() to handle BaseException properly
- Pass through st.rerun() and st.stop() without catching them
- Add comprehensive tests for control flow exceptions (59 tests total)
- Add nested ErrorBoundary behavior with hook execution order guarantees
- Improve test robustness by reducing index-based assertions
- Document nested boundary behavior in README (English and Japanese)
- Update codecov badge to use default branch instead of specific branch

### Tests added
- Control flow passthrough (st.rerun/st.stop in decorate and callbacks)
- Hook execution guarantees (no side effects for control flow)
- Nested boundary tests (inner handles, fallback bubbling, hook order)
- Edge cases (BaseException handling, import failures)